### PR TITLE
Add Minimize and Exit buttons to MainWindow

### DIFF
--- a/PowerHotkeys/MainWindow.xaml
+++ b/PowerHotkeys/MainWindow.xaml
@@ -290,7 +290,21 @@
                             Margin="0,0,8,0"/>
                     <Button Content="Settings" Width="70" Height="20" 
                             Click="SettingsButton_Click"
-                            Style="{StaticResource DarkButtonStyle}"/>
+                            Style="{StaticResource DarkButtonStyle}"
+                            Margin="0,0,8,0"/>
+                    <Button Name="MinimizeButton" Content="−" Width="30" Height="20" 
+                            Click="MinimizeButton_Click"
+                            Style="{StaticResource DarkButtonStyle}"
+                            ToolTip="Minimize to system tray"
+                            FontSize="14"
+                            FontWeight="Bold"
+                            Margin="0,0,4,0"/>
+                    <Button Name="ExitButton" Content="✕" Width="30" Height="20" 
+                            Click="ExitButton_Click"
+                            Style="{StaticResource DarkButtonStyle}"
+                            ToolTip="Exit application"
+                            FontSize="12"
+                            FontWeight="Bold"/>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/PowerHotkeys/MainWindow.xaml.cs
+++ b/PowerHotkeys/MainWindow.xaml.cs
@@ -265,6 +265,16 @@ public partial class MainWindow : Window
         }
     }
 
+    private void MinimizeButton_Click(object sender, RoutedEventArgs e)
+    {
+        HideWindow();
+    }
+
+    private void ExitButton_Click(object sender, RoutedEventArgs e)
+    {
+        ExitApplication();
+    }
+
     protected override void OnSourceInitialized(EventArgs e)
     {
         base.OnSourceInitialized(e);


### PR DESCRIPTION
- Introduced "Minimize" and "Exit" buttons in MainWindow.xaml with tooltips for user guidance.
- Implemented functionality for minimizing the window and exiting the application in MainWindow.xaml.cs.